### PR TITLE
refactor secure ID generation to use nanoid instead of uniqid

### DIFF
--- a/db/schema.ts
+++ b/db/schema.ts
@@ -1,5 +1,5 @@
 import { int, sqliteTable, text } from 'drizzle-orm/sqlite-core';
-import uniqid from 'uniqid';
+import { nanoid } from 'nanoid';
 
 export const eventsTable = sqliteTable('events_table', {
   id: int().primaryKey({ autoIncrement: true }),
@@ -14,9 +14,7 @@ export const eventsTable = sqliteTable('events_table', {
 /** An intersection table linking users to events */
 export const invitationsTable = sqliteTable('invitations_table', {
   id: int().primaryKey({ autoIncrement: true }),
-  secretKey: text()
-    .unique()
-    .$defaultFn(() => uniqid.process()),
+  secretKey: text().unique().$defaultFn(nanoid),
   didRsvp: int('did_rsvp', { mode: 'boolean' }),
   eventId: int('event_id')
     .references(() => eventsTable.id)

--- a/db/seed.ts
+++ b/db/seed.ts
@@ -1,7 +1,7 @@
 import { db } from './index.server';
 import { eventsTable, invitationsTable, usersTable } from './schema';
 import { faker } from '@faker-js/faker';
-import uniqid from 'uniqid';
+import { nanoid } from 'nanoid';
 
 const seed = async () => {
   await db.delete(eventsTable).all();
@@ -43,7 +43,7 @@ const seed = async () => {
       registrations.push({
         eventId: event.id!,
         userId: user.id!,
-        secretKey: uniqid.process(),
+        secretKey: nanoid(),
         didRsvp: false,
       });
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leave-by-nine-club",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "sideEffects": false,
   "type": "module",
@@ -32,10 +32,10 @@
     "drizzle-orm": "^0.35.3",
     "isbot": "^4.1.0",
     "lucide-react": "^0.453.0",
+    "nanoid": "^5.0.8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "sqlite3": "^5.1.7",
-    "uniqid": "^5.4.0"
+    "sqlite3": "^5.1.7"
   },
   "devDependencies": {
     "@faker-js/faker": "^9.0.3",
@@ -43,7 +43,6 @@
     "@types/node": "^22.7.7",
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.2.7",
-    "@types/uniqid": "^5",
     "@typescript-eslint/eslint-plugin": "^6.7.4",
     "@typescript-eslint/parser": "^6.7.4",
     "autoprefixer": "^10.4.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2089,13 +2089,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/uniqid@npm:^5":
-  version: 5.3.4
-  resolution: "@types/uniqid@npm:5.3.4"
-  checksum: 10c0/0075a77f2d67ef0cfeb5b55d27b059e4302ea4f5adb9038be198a344495df814778e5765cb69303ad7b22977f2d0a6bd98ed0b3a3120e89a8a724b8a2dff6272
-  languageName: node
-  linkType: hard
-
 "@types/unist@npm:^2, @types/unist@npm:^2.0.0":
   version: 2.0.11
   resolution: "@types/unist@npm:2.0.11"
@@ -6345,7 +6338,6 @@ __metadata:
     "@types/node": "npm:^22.7.7"
     "@types/react": "npm:^18.2.20"
     "@types/react-dom": "npm:^18.2.7"
-    "@types/uniqid": "npm:^5"
     "@typescript-eslint/eslint-plugin": "npm:^6.7.4"
     "@typescript-eslint/parser": "npm:^6.7.4"
     autoprefixer: "npm:^10.4.19"
@@ -6361,6 +6353,7 @@ __metadata:
     eslint-plugin-react-hooks: "npm:^4.6.0"
     isbot: "npm:^4.1.0"
     lucide-react: "npm:^0.453.0"
+    nanoid: "npm:^5.0.8"
     postcss: "npm:^8.4.38"
     prettier: "npm:3.3.3"
     prettier-plugin-tailwindcss: "npm:^0.6.8"
@@ -6370,7 +6363,6 @@ __metadata:
     tailwindcss: "npm:^3.4.4"
     tsx: "npm:^4.19.1"
     typescript: "npm:^5.1.6"
-    uniqid: "npm:^5.4.0"
     vite: "npm:^5.1.0"
     vite-tsconfig-paths: "npm:^4.2.1"
     vitest: "npm:^2.1.3"
@@ -7474,6 +7466,15 @@ __metadata:
   bin:
     nanoid: bin/nanoid.cjs
   checksum: 10c0/e3fb661aa083454f40500473bb69eedb85dc160e763150b9a2c567c7e9ff560ce028a9f833123b618a6ea742e311138b591910e795614a629029e86e180660f3
+  languageName: node
+  linkType: hard
+
+"nanoid@npm:^5.0.8":
+  version: 5.0.8
+  resolution: "nanoid@npm:5.0.8"
+  bin:
+    nanoid: bin/nanoid.js
+  checksum: 10c0/0281d3cc0f3d03fb3010b479f28e8ddedfafb9b5d60e54315589ef0a54a0e9cfcb0bf382dd3b620fdad6b72b8c1f5b89a15d55c6b6a9134b58b16eb230b3a3d7
   languageName: node
   linkType: hard
 
@@ -9989,13 +9990,6 @@ __metadata:
     trough: "npm:^2.0.0"
     vfile: "npm:^5.0.0"
   checksum: 10c0/da9195e3375a74ab861a65e1d7b0454225d17a61646697911eb6b3e97de41091930ed3d167eb11881d4097c51deac407091d39ddd1ee8bf1fde3f946844a17a7
-  languageName: node
-  linkType: hard
-
-"uniqid@npm:^5.4.0":
-  version: 5.4.0
-  resolution: "uniqid@npm:5.4.0"
-  checksum: 10c0/ef0d7c7ae26d5d7eb632ec9a1548575c855edfa422fd1ade1ee82d7d60bddef24574a53a5ec716db887ec763e4f5dea6dae4dfc1918e2ee5fda35dc43a6c0b7a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Another incredibly simple PR:

The `uniqid` package provided unique IDs, but they were very predictable. Not great for this kind of application.

Replacing with `nanoid` which is cryptographically secure, but shorter / more performant than `uuidv4`.